### PR TITLE
Fix GitHub link

### DIFF
--- a/omo-app/src/dapps/website/views/molecules/Footer.svelte
+++ b/omo-app/src/dapps/website/views/molecules/Footer.svelte
@@ -56,7 +56,7 @@
         <div class="flex flex-col">
           <span class="mb-2 font-bold text-gray-700 uppercase">Follow Us</span>
           <span class="my-2"><a
-              href="https://gihtub.com/omoearth"
+              href="https://github.com/omoearth"
               class="text-secondary text-md hover:text-blue-500">Github</a></span>
           <span class="my-2"><a
               href="https://twitter.com/omoearth"


### PR DESCRIPTION
I was trying out the app, and I noticed that the GitHub link in the footer of the website has a small typo. The link has `gihtub` instead of `github`. This PR fixes the link.